### PR TITLE
Build on MSYS2 MINGW64

### DIFF
--- a/makefile.msys2
+++ b/makefile.msys2
@@ -1,0 +1,57 @@
+TARGET=3dworld
+BUILD=obj
+VPATH=$(BUILD) src src/texture_tile_blend
+
+TARGA=Targa
+GLI=dependencies/gli
+GLM=dependencies/glm
+INCLUDES=-Isrc -Isrc/texture_tile_blend -I$(TARGA) -I$(GLI) -I$(GLM) -Idependencies/meshoptimizer/src -Idependencies/stb
+DEFINES=-DENABLE_PNG -DENABLE_TIFF -DENABLE_DDS -DENABLE_STB_IMAGE -DENABLE_ASSIMP
+# Note: extra warnings can be useful, but GLI and Targa generate too many warnings
+CXXFLAGS=-g -Wall -O3 -fopenmp $(INCLUDES) $(DEFINES) -Wextra -Wno-unused-parameter -Wno-implicit-fallthrough \
+#-Wstrict-aliasing=2 -Wunreachable-code -Wcast-align -Wcast-qual -Wsign-compare -Wsign-promo -Wdisabled-optimization -Winit-self -Wlogical-op -Wmissing-include-dirs -Wnoexcept -Woverloaded-virtual -Wredundant-decls -Wstrict-null-sentinel -Wno-unused -Wno-variadic-macros -Wno-parentheses -fdiagnostics-show-option -fasynchronous-unwind-tables -fexceptions -Werror=implicit-function-declaration -pedantic -pedantic-errors -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k -Wimport -Winvalid-pch -Wmissing-field-initializers -Wmissing-format-attribute -Wpacked -Wpointer-arith -Wstack-protector -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wunused -Wvariadic-macros -Wwrite-strings -Werror=return-type -D_GLIBCXX_ASSERTIONS -fexceptions -fasynchronous-unwind-tables -Wctor-dtor-privacy -Wnon-virtual-dtor
+OBJS=$(shell cat obj_list)
+
+LINK=$(CPP) -fopenmp $(INCLUDES)
+LDFLAGS=-lpthread `pkg-config --libs zlib libpng libtiff-4 glew freeglut freealut` -lopengl32 -lglu32 -fopenmp -lassimp
+
+# For creating dependencies files
+DEPFLAGS = -MT $@ -MMD -MP -MF $(BUILD)/$*.Td
+POSTCOMPILE = mv -f $(BUILD)/$*.Td $(BUILD)/$*.d
+
+# Change the verbosity of the makefile.
+ifeq ($(VERBOSE),1)
+Q :=
+else
+Q := @
+endif
+
+# Compile 3dworld
+all: $(TARGET)
+
+# Link the target
+$(TARGET): $(OBJS)
+	@echo "Linking $<"
+	$(Q)cd $(BUILD) && $(CXX) $(INCLUDES) -o $(TARGET) $(OBJS) $(LDFLAGS)
+
+# Compile source files
+%.o : %.cpp $(BUILD)/%.d
+	@echo "Compiling $<"
+	$(Q)$(CXX) $(DEPFLAGS) $(CXXFLAGS) $(INCLUDES) $(DEFINES) -c $(abspath $<) -o $(abspath $(BUILD)/$@)
+	@$(POSTCOMPILE)
+
+# Delete compiled files
+.PHONY: clean
+clean:
+	-rm -fr $(BUILD)
+
+# Create the directory before compiling sources
+$(OBJS): | $(BUILD)
+$(BUILD):
+	@mkdir -p $(BUILD)
+
+# Create the dependency files
+$(BUILD)/%.d: ;
+.PRECIOUS: $(BUILD)/%.d
+
+-include $(patsubst %,$(BUILD)/%.d,$(basename $(OBJS)))

--- a/src/3DWorld.cpp
+++ b/src/3DWorld.cpp
@@ -26,8 +26,8 @@
 
 #ifdef _WIN32
 extern "C" { // force use of dedicated GPUs rather than Intel integrated graphics
-	_declspec(dllexport) DWORD NvOptimusEnablement = 1;
-	_declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+	__declspec(dllexport) DWORD NvOptimusEnablement = 1;
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 }
 #endif
 

--- a/src/gl_includes.h
+++ b/src/gl_includes.h
@@ -13,7 +13,11 @@
 #include <GL/gl.h>
 
 #ifdef _WIN32
+#ifdef __MINGW32__
+#include <GL/freeglut.h>
+#else
 #include <freeglut.h>
+#endif
 #undef FAR // undefine conflicting defines picked up from windows headers
 #else // linux
 #include <GL/freeglut.h> // standard glut

--- a/src/openal_wrap.cpp
+++ b/src/openal_wrap.cpp
@@ -16,7 +16,7 @@ extern float CAMERA_RADIUS;
 #define ENABLE_OPENAL // comment this out to disable OpenAL sound support
 
 #ifdef ENABLE_OPENAL
-#ifdef _WIN32 // Note: the Windows OpenAL 1.1 SDK doesn't have the AL directory, but the openal-soft GitHub repo does
+#if defined(_WIN32) && !defined(__MINGW32__) // Note: the Windows OpenAL 1.1 SDK doesn't have the AL directory, but the openal-soft GitHub repo does
 #include <al.h>
 #include <alc.h>
 #else

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1,1 +1,0 @@
-../dependencies/meshoptimizer/src/simplifier.cpp

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1,0 +1,1 @@
+#include "../dependencies/meshoptimizer/src/simplifier.cpp"

--- a/src/targa.cpp
+++ b/src/targa.cpp
@@ -1,1 +1,0 @@
-../Targa/targa.cpp

--- a/src/targa.cpp
+++ b/src/targa.cpp
@@ -1,0 +1,1 @@
+#include "../Targa/targa.cpp"

--- a/src/texture_tile_blend.cpp
+++ b/src/texture_tile_blend.cpp
@@ -1,0 +1,1 @@
+#include "texture_tile_blend/texture_tile_blend.cpp"

--- a/src/texture_tile_blend.cpp
+++ b/src/texture_tile_blend.cpp
@@ -1,1 +1,0 @@
-texture_tile_blend/texture_tile_blend.cpp


### PR DESCRIPTION
- Remove MSVC specifics
- Replace symbolic links with real files
- Create makefile.msys2 for MSYS2 MINGW64